### PR TITLE
Fold list of books page into site

### DIFF
--- a/docs/user-guide/books.md
+++ b/docs/user-guide/books.md
@@ -1,0 +1,50 @@
+# Books
+
+## [illumos Developer's Guide](https://illumos.org/books/dev/)
+
+This guide covers the basic workflow for developing illumos and then dives into
+specific detail on everything from the layout of the gate to several HOWTOs.
+Whether this is your first time working with illumos or you remember back when
+the code in the gate all referred to something called SunOS, this guide will
+help you in enhancing and fixing illumos.
+
+## [Dynamic Tracing Guide](https://illumos.org/books/dtrace/)
+
+DTrace is a comprehensive dynamic tracing framework for the illumos Operating
+System. DTrace provides a powerful infrastructure to permit administrators,
+developers, and service personnel to concisely answer arbitrary questions about
+the behavior of the operating system and user programs. The illumos Dynamic
+Tracing Guide describes how to use DTrace to observe, debug, and tune system
+behavior. This book also includes a complete reference for bundled DTrace
+observability tools and the D programming language.
+
+## [Modular Debugger Guide](https://illumos.org/books/mdb/)
+
+The Modular Debugger (MDB) is a highly extensible, general purpose debugging
+tool for the illumos Operating System. The Modular Debugger Guide describes
+how to use MDB to debug complex software systems, with a particular emphasis on
+the facilities available for debugging the illumos kernel and associated device
+drivers and modules. It also includes a complete reference for and discussion
+of the MDB language syntax, debugger features, and MDB Module Programming API.
+
+## [Writing Device Drivers](https://illumos.org/books/wdd/)
+
+Writing Device Drivers provides information on developing drivers for
+character-oriented devices, block-oriented devices, network devices, SCSI
+target and HBA devices, and USB devices for the illumos Operating System
+(illumos). This book discusses how to develop multithreaded reentrant device
+drivers for all architectures that conform to the illumos DDI/DKI (Device
+Driver Interface, Driver-Kernel Interface). A common driver programming
+approach is described that enables drivers to be written without concern for
+platform-specific issues such as endianness and data ordering.
+
+Additional topics include hardening illumos drivers; power management; driver
+autoconfiguration; programmed I/O; Direct Memory Access (DMA); device context
+management; compilation, installation, and testing drivers; debugging drivers;
+and porting illumos drivers to a 64-bit environment.
+
+## [Memory and Thread Placement Optimization Developer's Guide](https://illumos.org/books/lgrps/)
+
+The Memory and Thread Placement Optimization Developer's Guide provides
+information on locality groups and the technologies that are available to
+optimize the use of computing resources in the illumos operating system.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -8,7 +8,7 @@ distro](../about/distro.md) and start playing.
 
 ## Books
 
-We provide a number of [books](https://illumos.org/books/) relating to illumos
+We provide a number of [books](./books.md) relating to illumos
 technologies.
 
 If your goal is to work on illumos itself, the [Developer's

--- a/docs/user-guide/manual.md
+++ b/docs/user-guide/manual.md
@@ -1,13 +1,13 @@
 # Manual pages
 
 You can browse (and link to) the illumos manual pages
-[online](http://illumos.org/man/all).
+[online](https://illumos.org/man/all).
 
 ## History
 
 The manual pages integrated into illumos-gate are taken from the last source
-drop provided by Sun at http://dlc.sun.com/osol/man/downloads. These are
-outdated in several respects.
+drop provided by Sun at `http://dlc.sun.com/osol/man/downloads`. These sources
+were outdated in several respects:
 
 * They are missing descriptions of new features
 * They may still describe some old features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,8 @@ pages:
   - 'User Guide':
     - 'Getting Started': 'user-guide/index.md'
     - 'Bug Reporting': 'user-guide/bugs.md'
-    - 'Manuals': 'user-guide/manual.md'
+    - 'Books': 'user-guide/books.md'
+    - 'Manual Pages': 'user-guide/manual.md'
     - 'Debugging':
       - 'Overview': 'user-guide/debug.md'
       - 'Systems': 'user-guide/debug-systems.md'


### PR DESCRIPTION
I figured we should fold in the [books page](https://illumos.org/books/) into here so that it has the same styling and side bar links. I've also made some minor changes to `manual.md`.