### PR TITLE
update build.md

### DIFF
--- a/docs/developers/build.md
+++ b/docs/developers/build.md
@@ -273,7 +273,7 @@ Run the following command to start the full build:
 
 ```
 cd /code/illumos-gate
-time ksh93 usr/src/tools/scripts/nightly.sh illumos.sh
+time ksh93 usr/src/tools/scripts/nightly illumos.sh
 ```
 
 The build creates a _lot_ of output, so rather than emit it directly to the
@@ -316,7 +316,7 @@ The `-i` flag to `nightly.sh` performs an incremental build:
 
 ```
 cd /code/illumos-gate
-time ksh93 usr/src/tools/scripts/nightly.sh -i illumos.sh
+time ksh93 usr/src/tools/scripts/nightly -i illumos.sh
 ```
 
 !!! note


### PR DESCRIPTION
Modification in Build.md 
when trying building illumos in my openindiana system i used this command: 
**time ksh93 usr/src/tools/scripts/nightly.sh illumos.sh** as it is mentioned in the starting build part of the file build.md, which makes an error, that i resolved by deleting **.sh** from nightly. 
and i did the same thing for the command: **time ksh93 usr/src/tools/scripts/nightly.sh -i illumos.sh**
in the Performing an incremental build part.