### PR TITLE
add Danube Cloud to list of illumos distros

### DIFF
--- a/docs/about/distro.md
+++ b/docs/about/distro.md
@@ -27,3 +27,4 @@ For major feature differences, the following chart may be helpful.
 | [DilOS](http://www.dilos.org/) | igork | Workstation, Servers | | <i class="material-icons">check</i> | APT | <i class="material-icons">check</i> | <i class="material-icons">check</i> | <i class="material-icons">check</i> | <i class="material-icons">check</i> |
 | [XStreamOS](http://www.sonicle.com/xstreamos/) | [Sonicle](http://www.sonicle.com/) | Server | |<i class="material-icons">check</i> | |
 | [v9os](http://www.milax.fi/v9os.html) | [MilaX](http://www.milax.fi/) | Server | | <i class="material-icons">check</i> | IPS | | <i class="material-icons">check</i> |
+| [Danube Cloud](https://danube.cloud) | [Danube Cloud Community](https://github.com/erigones/esdc-ce) | Hypervisor | Proxmox | <i class="material-icons">check</i> | [pkgsrc](https://pkgsrc.joyent.com) | <i class="material-icons">check</i> |  | <i class="material-icons">check</i> | <i class="material-icons">check</i> |


### PR DESCRIPTION
Hi,
Danube Cloud project is alive for at least 7 years now. I'd like to include it in the distro list. It's based on SmartOS with downstream patches and includes a featureful management GUI/API on top of it.
Thanks.
Jan