### PR TITLE
update OmniOS IRC network

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -30,6 +30,6 @@ community mailing list information.
 | -------     | ------------ | -------------- |
 | illumos     | freenode     | `#illumos`     |
 | SmartOS     | freenode     | `#smartos`     |
-| OmniOS      | freenode     | `#omnios`      |
+| OmniOS      | libera       | `#omnios`      |
 | OpenIndiana | freenode     | `#openindiana` |
 | OpenZFS     | freenode     | `#openzfs`     |


### PR DESCRIPTION
According to [this tweet](https://twitter.com/OmniOSce/status/1396770950406934531?s=20), the OmniOS project has officially moved to the Libera network as of May 24, 2021. This is also updated in the project's [Contact Us](https://omnios.org/about/contact) page.