### PR TITLE
Switch to `readthedocs` theme (included with mkdocs)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,6 @@
-![logo](images/logo.png) illumos is a Unix operating system which provides
+![logo](images/logo.png) 
+
+illumos is a Unix operating system which provides
 next-generation features for downstream [distributions](about/distro.md),
 including [advanced system debugging](http://dtrace.org/guide/), [next
 generation filesystem](http://open-zfs.org/), networking, and virtualization

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,16 +37,16 @@ nav:
     - 'Events': 'community/events.md'
     - 'Videos': 'community/videos.md'
 
-theme:
-  name: null
-  custom_dir: 'material-illumos'
-  language: en
-  logo: 'assets/images/illumos.svg'
-  palette:
-  feature:
-    tabs: false
-  include_search_page: false
-  search_index_only: true
+theme: readthedocs
+  # name: null
+  # custom_dir: 'material-illumos'
+  # language: en
+  # logo: 'assets/images/illumos.svg'
+  # palette:
+  # feature:
+  #   tabs: false
+  # include_search_page: false
+  # search_index_only: true
 
 extra:
   social:


### PR DESCRIPTION
reason: quickly fix search links

The newlines in docs/index.html makes the layout look slightly better
with this theme.

(This commit does not remove the custom theme so it can be reactivated quickly if it is fixed.)