### PR TITLE
gerrit.md: add scp port for download commit-msg hook

### DIFF
--- a/docs/contributing/gerrit.md
+++ b/docs/contributing/gerrit.md
@@ -110,7 +110,7 @@ you have the footer is to install the hook script that Gerrit supplies:
 
 ```
 $ cd ~/illumos
-$ scp walter@code.illumos.org:hooks/commit-msg .git/hooks/
+$ scp -p -P 29418 walter@code.illumos.org:hooks/commit-msg .git/hooks/
 ```
 
 You'll make your change in your local clone.  It is generally easiest to start


### PR DESCRIPTION
The describted kind of download the commit-msg hook do not work on standard SSH port. It works with the port mentioned in Gerrit Documentation cmd-hook-commit-msg.txt