### PR TITLE
contributing: update link to bite-sized bugs query

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -23,8 +23,9 @@ Zezeski](https://zinascii.com/) going through fixing a bug in ZFS in this
 ## Finding An Area To Contribute To
 
 If you're not sure what you want to work on, you can start by looking at our
-[list of bite-size bugs](https://www.illumos.org/projects/illumos-gate/issues?query_id=31) which
-should be easy for newcomers to pick up. You can also look at the entire list
+[list of bite-size
+bugs](https://www.illumos.org/projects/illumos-gate/issues?query_id=31) which
+should be easy for newcomers to pick up.  You can also look at the entire list
 of issues and see if any with status "New" fit your skill set.
 
 If you are adding a new feature or addressing a problem not currently on our

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -23,7 +23,7 @@ Zezeski](https://zinascii.com/) going through fixing a bug in ZFS in this
 ## Finding An Area To Contribute To
 
 If you're not sure what you want to work on, you can start by looking at our
-[list of bite-size bugs](https://www.illumos.org/issues?query_id=15) which
+[list of bite-size bugs](https://www.illumos.org/projects/illumos-gate/issues?query_id=31) which
 should be easy for newcomers to pick up. You can also look at the entire list
 of issues and see if any with status "New" fit your skill set.
 


### PR DESCRIPTION
Fix the link to bite-size bugs; it's otherwise inaccessible to new users. Assuming this link should match `illumos-gate` in the next paragraph.