### PR TITLE
contributing: advice from recent RTI learnings

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -235,7 +235,7 @@ the previous commit.
 If your commit does not yet include "Reviewed by:" indicating your reviewers,
 this is when you should add those lines. We do not have a blank line between the
 first line of a commit message in illumos, and the following "Reviewed by:"
-lines. When you run `git format-patch` to get a patch to include, this will
+lines. If you run `git format-patch` to get a patch to include, this will
 result in an oddly-formatted "Subject:" line - that is expected and OK.
 
 !!! note Assembling "Reviewed by:" lines
@@ -257,19 +257,17 @@ result in an oddly-formatted "Subject:" line - that is expected and OK.
 
 If your change has been reviewed on Gerrit, you (or `git pbchk`) may have found
 trivial changes such as whitespace nits, comment spelling, or copyright dates
-since the last round of review. Please ensure any changes at this point are also
-pushed to Gerrit. Core team members receiving your request may fetch your patch
-from Gerrit or the email depending on which happens to be easier to access for
-them. The commit hash of your patch on Gerrit and via `git format-patch` may be
-different, particularly if you've removed a "Change-ID:" line before generating
-your patch for RTI. This is expected and OK.
+since the last round of review. Please ensure any changes at this point are
+also pushed to Gerrit. If your changes on Gerrit are the same as you would
+include as a patch for integration, you can omit the patch from your RTI e-mail
+entirely; the core team can fetch your change from Gerrit as well.
 
 Your RTI e-mail should include:
 
 * The link to the illumos issue(s) you're fixing, e.g.,
   https://illumos.org/issues/10052
-* A link to the changes that were reviewed; e.g., a link to your
-  [Gerrit](./gerrit) review
+* The changes that were reviewed; e.g., a link to your [Gerrit](./gerrit)
+  review, or an attached patch otherwise.
 * The full "change set description" (i.e., `git whatchanged -v origin/master..`)
   including:
     * Issue number(s) and description(s)
@@ -281,7 +279,6 @@ Your RTI e-mail should include:
   compilers, as noted above)
 * Information about how the changes were tested (it's sufficient to
   mention that the testing notes appear in the bug tracker)
-* Your changes attached as a patch as per `git format-patch`
 
 Here is an example change description:
 
@@ -292,10 +289,12 @@ Reviewed by: Ohana Matsumae <ohana@kissui.ishikawa.jp>
 ```
 
 Note this description does not include a "Change-ID:" line - it is the
-description the commit should have when integrated, minus "Approved by:". In
-the patch provided, you may or may not have a Gerrit "Change-ID:" line. If your
-RTI is approved, the core team member integrating your patch will remove this
-line from the description, and add an "Approved by:" recording their approval.
+description the commit should have when integrated, minus "Approved by:". Since
+Gerrit identifies changes with the "Change-ID:" line, this will be a little
+different from the description in the associated Gerrit link. This is okay! If
+your RTI is approved, the core team member integrating your patch will remove
+this line from the description when they add an "Approved by:" recording their
+approval.
 
 !!! note Amending descriptions
     You can use `git commit --amend` to edit the commit message.


### PR DESCRIPTION
observations i found useful in figuring out what i should do to get _to_ RTI email materials. the contributing docs are clear enough on what goes in the email, but i had a harder time figuring out if what i was putting together had the right information.

generally i had a hard time figuring out what the human on the receiving end needs or will do, so i'm trying to be clearer about that without being prescriptive. in particular, understanding that better from talking with @citrus-it is what helped me understand the variance in RTIs in practice.

it seems like the patch file itself can be optional if the correct patch is reflected in Gerrit, that `pbchk` isn't necessary if it's empty, contributors provide `Reviewed by:` (no tooling on the Gerrit or integrator side). `whatchanged` can either be in-line in the email if it is tiny, or attached if it would be large. these are what the RTI is expected to look like, if it differs that's not necessarily a problem but may place additional burden on the core team, so.. don't do that lightly.

in particular i'd looked at a few prior RTIs and saw that generally patches on the mailing list are not the same commit as on Gerrit, and that the patch subject line is basically uninteresting to the RTI recipient. it seems like if i was going to outline what core members are seeking, it is:

* if on Gerrit, patch on Gerrit with `Change-ID:` which will be removed
* if via email, patch contents from email, patch description from `whatchanged`
* `mail_msg` in either case that describes the build when integrating the patch

finally, if you're like me and hop between commits regularly, `mail_msg` will be bogus if you built the gate, built a different commit, then switched to your RTI commit and built _that_. so also a heads to folks that that will not be good for RTI!

an open question i have here is: if my change was reviewed on Gerrit, and i've amended that commit like
```
issue# title
Reviewed by: name <email>

Change-ID: I1234
```

then is there value submitting the patch in my RTI email? personally speaking, that risks me attaching an incorrect commit, or Gerrit having a hopefully-minor stale commit that was in the email. this depends on how the core team fetches patches for integration. https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#get-patch can a change as a patch in base64, so "patch optional if using Gerrit" would be _nice_ as a formal policy.