### PR TITLE
Replace 'git whatchanged' with 'git log --stat' 

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -268,8 +268,9 @@ Your RTI e-mail should include:
   https://illumos.org/issues/10052
 * The changes that were reviewed; e.g., a link to your [Gerrit](./gerrit)
   review, or an attached patch otherwise.
-* The full "change set description" (i.e., `git whatchanged -v origin/master..`)
-  including:
+* If attaching a patch, please include a full "change set description"
+  (i.e., the output of `git log --stat -v origin/master..`) in the body of the
+  message, including:
     * Issue number(s) and description(s)
     * `Reviewed by: First Last <first.last@example.com>` lines
     * List of files affected


### PR DESCRIPTION
The `git whatchanged` command is deprecated in git 2.51.0; recent git documentation suggests using `git log --raw --no-merges` instead.   

I brought this up on IRC; rough consensus among advocates on IRC was that we should no longer require this for changes via Gerrit; additionally, several advocates suggested that `git log --stat` output was more useful than `--raw`.
